### PR TITLE
Extend gitignore to exclude common IDE files etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,63 @@
-*egg-info/
-dist/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+bin/
 build/
-docs/build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
 .coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+# Pycharm
+.idea
+
+# Sphinx documentation
+docs/_build/
+docs/build/
+
+# Mac
+.DS_Store
+
+# Pyenv
+.python-version


### PR DESCRIPTION
Makes it a bit more convenient to work with the repo.
