### PR TITLE
sometimes tcp stack might take time to release a port

### DIFF
--- a/tests/tornado_based/test_auth.py
+++ b/tests/tornado_based/test_auth.py
@@ -146,7 +146,7 @@ class CurveTestCase(tornado.testing.AsyncTestCase):
 
         client_id = b'john'
         server_id = b'server'
-        endpoint = 'tcp://127.0.0.1:8998'
+        endpoint = b'tcp://127.0.0.1:8999'
         server_public, server_secret = zmq.curve_keypair()
         client_public, client_secret = zmq.curve_keypair()
         security_plugin = 'untrusted_curve'


### PR DESCRIPTION
increase the port number to avoid collision with another test
