### PR TITLE
Do not extract function name if given explicitly by user

### DIFF
--- a/pseud/utils.py
+++ b/pseud/utils.py
@@ -72,13 +72,16 @@ class RPCCallable(object):
 
 def register_rpc(func=None, name=None, domain='default', registry=registry):
     def wrapper(fn):
-        try:
-            # PY3 or PY2+future
-            fn_name = fn.__name__
-        except AttributeError:
-            # PY2
-            fn_name = fn.func_name
-        endpoint_name = name or fn_name
+        if name is None:
+            try:
+                # PY3 or PY2+future
+                fn_name = fn.__name__
+            except AttributeError:
+                # PY2
+                fn_name = fn.func_name
+            endpoint_name = fn_name
+        else:
+            endpoint_name = name
         registered_name = '{}:{}'.format(endpoint_name, domain)
         registry.registerUtility(RPCCallable(fn, name=endpoint_name,
                                              domain=domain),

--- a/tests/run_last/test_rpc_registry.py
+++ b/tests/run_last/test_rpc_registry.py
@@ -1,3 +1,5 @@
+import functools
+
 import pytest
 from zope.interface.registry import Components
 
@@ -27,6 +29,12 @@ def test_rpc_simple_registration():
 
     assert isinstance(get_rpc_callable('totally.something.else'),
                       RPCCallable)
+
+    def call_me_again():
+        return True
+
+    register_rpc(functools.partial(call_me_again), name='call_me_again')
+    assert get_rpc_callable('call_me_again')() is True
 
 
 def test_rpc_restricted_registration():


### PR DESCRIPTION
Useful to register functions decorated by partial
