### PR TITLE
Enable PROBING

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,8 +204,12 @@ take into consideration the user_id to perform the routing.
    client = Client('service',
                    security_plugin='plain',
                    user_id='alice',
-                   password='')
+                   password='',
+                   io_loop=io_loop)
    client.connect('tcp://127.0.0.1:5555')
+   client.start()
+   # Now the client will automatically send a PROBING message to its peer,
+   # to register itself.
 
    # Action that the client will perform when
    # requested by the server.
@@ -213,20 +217,9 @@ take into consideration the user_id to perform the routing.
    def sheep():
        return 'beeeh'
 
-   # The client needs to perform a first call
-   # to the server in order to register itself.
-   # on production this will be handle automatically
-   # by the heartbeat backend. The first heartbeat will
-   # trigger the authentication. Then until the client
-   # disconnect the server will not ask the client
-   # to reconnect.
 
-   # assume we are inside a coroutine
-   result = yield client.hello('alice')
-   assert result == 'Hello alice'
-
-Back on server side, now the client as registered itself, we can send
-to it any commands the client is able to do.
+Back on server side, now the client as registered itself thanks to PROBING, we can send
+to it any commands the client is allowed to execute.
 
 .. code-block:: python
 

--- a/docs/source/remote-calls.rst
+++ b/docs/source/remote-calls.rst
@@ -143,28 +143,21 @@ to the client:
    client = Client('service',
                     security_plugin='plain',
                     user_id='client1',
-                    password='')
+                    password='',
+                    io_loop=io_loop)  # io_loop is your current io_loop
 
    client.connect('tcp://127.0.0.1:5555')
+   client.start()
 
    @client.register_rpc
    def addition(a, b):
        return a + b
 
-   client.hello('Me')  # perform a first call to register itself
-
-.. note::
-
-    The client needs to perform at least one call to the server
-    to register itself. Otherwise the server won't know a client is connected
-    to it. On real condition the heartbeat backend will take care of it.
-    So you do not have to worry about it.
 
 .. code:: python
 
    # server.py
 
-   # gevent api
    server.send_to('client1').addition(2, 4).get() == 6
 
 .. note::

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(name='pseud',
           'pytest-pep8',
           'pytest-capturelog',
           'coveralls',
+          'tornado>=4.1'
           'tox',
       ],
       cmdclass={'test': PyTest},

--- a/tests/gevent_based/test_bidirectional.py
+++ b/tests/gevent_based/test_bidirectional.py
@@ -71,9 +71,6 @@ def test_server_can_send():
     import string
     register_rpc(name='string.lower')(string.lower)
 
-    result = client.string.lower('TATA').get()
-    assert result == 'tata'
-
     future = server.send_to(client_id).string.lower('SCREAM')
 
     assert future.get() == 'scream'
@@ -106,8 +103,6 @@ def test_server_can_send_to_several_client():
 
     import string
     register_rpc(name='string.lower')(string.lower)
-    client1.string.lower('TATA').get()
-    client2.string.lower('TATA').get()
 
     future1 = server.send_to('client1').string.lower('SCREAM1')
 

--- a/tests/gevent_based/test_client.py
+++ b/tests/gevent_based/test_client.py
@@ -82,6 +82,8 @@ def test_job_executed():
 
     future = client.please.do_that_job(1, 2, 3, b=4)
     request = gevent.spawn(socket.recv_multipart).get()
+    _, _ = request
+    request = gevent.spawn(socket.recv_multipart).get()
     routing_id, delimiter, version, uid, message_type, message = request
     assert delimiter == ''
     assert version == VERSION
@@ -112,6 +114,8 @@ def test_job_server_never_reply():
     client.connect(endpoint + ':{}'.format(port))
 
     future = client.please.do_that_job(1, 2, 3, b=4)
+    request = gevent.spawn(socket.recv_multipart).get()
+    _, _ = request
     request = gevent.spawn(socket.recv_multipart).get()
     server_id, delimiter, version, uid, message_type, message = request
     assert delimiter == ''

--- a/tests/run_last/test_sync_client.py
+++ b/tests/run_last/test_sync_client.py
@@ -32,8 +32,7 @@ def make_one_server_thread(context, identity, endpoint, callback):
     router_sock = context.socket(zmq.ROUTER)
     router_sock.identity = identity
     router_sock.bind(endpoint)
-    response = router_sock.recv_multipart()
-    callback(router_sock, response)
+    callback(router_sock)
 
 
 def make_one_client(timeout=5):
@@ -67,7 +66,9 @@ def test_job_executed():
     endpoint = 'ipc://{}'.format(__name__)
     peer_identity = b'server'
 
-    def server_callback(socket, request):
+    def server_callback(socket):
+        _ = socket.recv_multipart()  # PROBING
+        request = socket.recv_multipart()
         peer_id, _, version, uid, message_type, message = request
         assert _ == b''
         assert version == VERSION
@@ -102,7 +103,9 @@ def test_job_failure():
     endpoint = 'ipc://{}'.format(__name__)
     peer_identity = b'server'
 
-    def server_callback(socket, request):
+    def server_callback(socket):
+        _ = socket.recv_multipart()  # PROBING
+        request = socket.recv_multipart()
         peer_id, _, version, uid, message_type, message = request
         assert _ == b''
         assert version == VERSION
@@ -138,7 +141,9 @@ def test_job_failure_service_not_found():
     endpoint = 'ipc://{}'.format(__name__)
     peer_identity = b'server'
 
-    def server_callback(socket, request):
+    def server_callback(socket):
+        _ = socket.recv_multipart()  # PROBING
+        request = socket.recv_multipart()
         peer_id, _, version, uid, message_type, message = request
         assert _ == b''
         assert version == VERSION

--- a/tests/tornado_based/test_bidirectional.py
+++ b/tests/tornado_based/test_bidirectional.py
@@ -74,7 +74,10 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
         yield client.start()
 
         register_rpc(name='string.lower')(str.lower)
-        yield client.string.lower('TATA')
+
+        # Let the probing functionality some time to finish
+        for _ in range(4):
+            yield tornado.gen.moment
 
         result = yield server.send_to(b'alice').string.lower('SCREAM')
         assert result == 'scream'
@@ -107,9 +110,10 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
 
         register_rpc(name='string.lower')(str.lower)
 
-        # call the server to register
-        yield client1.string.lower('TATA')
-        yield client2.string.lower('TATA')
+        # Let the probing functionality some time to finish
+        for _ in range(4):
+            yield tornado.gen.moment
+
         result1 = yield server.send_to(b'alice').string.lower('SCREAM1')
 
         result2 = yield server.send_to(b'bob').string.lower('SCREAM2')

--- a/tests/tornado_based/test_client.py
+++ b/tests/tornado_based/test_client.py
@@ -93,6 +93,8 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
         future = client.please.do_that_job(1, 2, 3, b=4)
         yield async_sleep(self.io_loop, .1)
         request = yield tornado.gen.Task(stream.on_recv)
+        _, _ = request
+        request = yield tornado.gen.Task(stream.on_recv)
         client_routing_id, delimiter, version, uid, message_type, message =\
             request
         assert delimiter == b''
@@ -128,8 +130,11 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
         client.connect(endpoint)
 
         stream = zmqstream.ZMQStream(socket, io_loop=self.io_loop)
+
         future = client.please.do_that_job(1, 2, 3, b=4)
         yield async_sleep(self.io_loop, .1)
+        request = yield tornado.gen.Task(stream.on_recv)
+        _, _ = request
         request = yield tornado.gen.Task(stream.on_recv)
         _, delimiter, version, uid, message_type, message = request
         assert delimiter == b''

--- a/tests/tornado_based/test_client.py
+++ b/tests/tornado_based/test_client.py
@@ -60,6 +60,7 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
         from pseud.common import AttributeWrapper
         endpoint = 'ipc://{}'.format(__name__).encode()
         peer_routing_id = b'echo'
+        socket = self.make_one_server_socket(peer_routing_id, endpoint)
         client = self.make_one_client(peer_routing_id,
                                       io_loop=self.io_loop)
         method_name = 'a.b.c.d'

--- a/tests/tornado_based/test_client.py
+++ b/tests/tornado_based/test_client.py
@@ -74,7 +74,7 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
         assert wrapper.name == method_name
         with pytest.raises(TimeoutError):
             future = wrapper()
-            future.result(timeout=.1)
+            future.result(timeout=.01)
         client.stop()
 
     @tornado.testing.gen_test

--- a/tests/tornado_based/test_client.py
+++ b/tests/tornado_based/test_client.py
@@ -79,7 +79,6 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_job_executed(self):
-        from pseud._tornado import async_sleep
         from pseud.interfaces import OK, VERSION, WORK
         from pseud.packer import Packer
         peer_routing_id = b'echo'
@@ -91,7 +90,6 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
 
         stream = zmqstream.ZMQStream(socket, io_loop=self.io_loop)
         future = client.please.do_that_job(1, 2, 3, b=4)
-        yield async_sleep(self.io_loop, .1)
         request = yield tornado.gen.Task(stream.on_recv)
         _, _ = request
         request = yield tornado.gen.Task(stream.on_recv)
@@ -118,7 +116,6 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_job_server_never_reply(self):
-        from pseud._tornado import async_sleep
         from pseud.interfaces import VERSION, WORK
         from pseud.packer import Packer
         peer_routing_id = b'echo'
@@ -132,7 +129,6 @@ class ClientTestCase(tornado.testing.AsyncTestCase):
         stream = zmqstream.ZMQStream(socket, io_loop=self.io_loop)
 
         future = client.please.do_that_job(1, 2, 3, b=4)
-        yield async_sleep(self.io_loop, .1)
         request = yield tornado.gen.Task(stream.on_recv)
         _, _ = request
         request = yield tornado.gen.Task(stream.on_recv)

--- a/tests/tornado_based/test_server.py
+++ b/tests/tornado_based/test_server.py
@@ -53,14 +53,16 @@ def test_server_with_its_loop_instance():
             server.stop()
 
         stop_thread = threading.Thread(
-            target=functools.partial(stop_server, server, can_stop))
+            target=stop_server,
+            args=(server, can_stop))
 
         stop_thread.start()
         server.start()
 
     can_stop = threading.Event()
     server_thread = threading.Thread(
-        target=functools.partial(start_server, can_stop))
+        target=start_server,
+        args=(can_stop,))
     server_thread.start()
 
     client = SyncClient()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ commands=py.test --pep8
 
 deps=pytest
      pytest-pep8
-     tornado
+     tornado>=4.1
      future
      py27: gevent
      py27: futures


### PR DESCRIPTION
Make sure the client is registered from server (the binder).
It removes necessity to use an heartbeat plugin to perform the first call
that will register the client.
