### PR TITLE
Remove encoding keywords for latest msgpack

### DIFF
--- a/pseud/packer.py
+++ b/pseud/packer.py
@@ -62,7 +62,7 @@ class Packer:
 
     def packb(self, data):
         try:
-            return msgpack.packb(data, encoding='utf-8', use_bin_type=True,
+            return msgpack.packb(data, use_bin_type=True,
                                  default=self.ext_type_pack_hook)
         except Exception:
             logger.exception('Packing failed')
@@ -70,7 +70,7 @@ class Packer:
 
     def unpackb(self, packed):
         try:
-            return msgpack.unpackb(packed, use_list=False, encoding='utf-8',
+            return msgpack.unpackb(packed, use_list=False,
                                    ext_hook=self.ext_type_unpack_hook)
         except Exception:
             logger.exception('Unpacking failed')


### PR DESCRIPTION
Latest version of  `msgpack.fallback.Packer` does not contains keyword `encoding`, remove it